### PR TITLE
Unit 2: Ingestion shared infrastructure

### DIFF
--- a/ingestion/config.py
+++ b/ingestion/config.py
@@ -1,0 +1,66 @@
+"""Shared ingestion configuration.
+
+Loads settings from environment variables with sensible defaults. Uses
+``pydantic-settings`` when available, falling back to a plain ``dataclass``
+with ``os.getenv`` so the package still imports in minimal environments
+(CI, smoke tests) without the optional dependency installed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+# Resolve the repo root once: this file lives at <repo>/ingestion/config.py
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_DEFAULT_PG_DSN = "postgresql://knowledge:knowledge@localhost:5433/tw_electronics"
+_DEFAULT_OLLAMA_URL = "http://localhost:11434"
+_DEFAULT_EMBEDDING_MODEL = "bge-m3"
+_DEFAULT_EMBEDDING_DIM = 1024
+_DEFAULT_TZ = "Asia/Taipei"
+
+
+try:
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+    class Settings(BaseSettings):
+        """Typed settings backed by environment variables."""
+
+        model_config = SettingsConfigDict(
+            env_file=".env",
+            env_file_encoding="utf-8",
+            extra="ignore",
+            case_sensitive=False,
+        )
+
+        pg_news_dsn: str = _DEFAULT_PG_DSN
+        pg_trading_dsn: str = _DEFAULT_PG_DSN
+        ollama_base_url: str = _DEFAULT_OLLAMA_URL
+        embedding_model: str = _DEFAULT_EMBEDDING_MODEL
+        embedding_dim: int = _DEFAULT_EMBEDDING_DIM
+        repo_root: Path = _REPO_ROOT
+        tz: str = _DEFAULT_TZ
+        finmind_token: Optional[str] = None
+
+except ImportError:  # pragma: no cover - exercised only without pydantic-settings
+    from dataclasses import dataclass, field
+
+    def _get_env(key: str, default: str) -> str:
+        return os.getenv(key.upper(), default)
+
+    @dataclass
+    class Settings:  # type: ignore[no-redef]
+        pg_news_dsn: str = field(default_factory=lambda: _get_env("pg_news_dsn", _DEFAULT_PG_DSN))
+        pg_trading_dsn: str = field(default_factory=lambda: _get_env("pg_trading_dsn", _DEFAULT_PG_DSN))
+        ollama_base_url: str = field(default_factory=lambda: _get_env("ollama_base_url", _DEFAULT_OLLAMA_URL))
+        embedding_model: str = field(default_factory=lambda: _get_env("embedding_model", _DEFAULT_EMBEDDING_MODEL))
+        embedding_dim: int = field(default_factory=lambda: int(_get_env("embedding_dim", str(_DEFAULT_EMBEDDING_DIM))))
+        repo_root: Path = field(default_factory=lambda: Path(_get_env("repo_root", str(_REPO_ROOT))))
+        tz: str = field(default_factory=lambda: _get_env("tz", _DEFAULT_TZ))
+        finmind_token: Optional[str] = field(default_factory=lambda: os.getenv("FINMIND_TOKEN"))
+
+
+# Module-level singleton used by other ingestion modules.
+settings = Settings()

--- a/ingestion/db.py
+++ b/ingestion/db.py
@@ -1,0 +1,92 @@
+"""Database pool, embedding client, and run logging helpers.
+
+Thin async wrappers that collectors share:
+- ``get_pool()`` returns a lazily-created ``asyncpg.Pool``.
+- ``embed(text)`` hits Ollama's ``/api/embeddings`` endpoint.
+- ``log_run(...)`` inserts a row into the ``ingest_runs`` table.
+- ``close()`` releases the pool and HTTP client on shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from .config import settings
+
+_pool_lock = asyncio.Lock()
+_client_lock = asyncio.Lock()
+
+_pool = None           # type: ignore[var-annotated]  # asyncpg.Pool
+_http_client = None    # type: ignore[var-annotated]  # httpx.AsyncClient
+
+
+async def get_pool():
+    """Return a lazily-initialized asyncpg connection pool (singleton)."""
+    global _pool
+    if _pool is None:
+        async with _pool_lock:
+            if _pool is None:
+                import asyncpg  # local import keeps optional dep lazy
+                _pool = await asyncpg.create_pool(dsn=settings.pg_news_dsn)
+    return _pool
+
+
+async def _get_http_client():
+    global _http_client
+    if _http_client is None:
+        async with _client_lock:
+            if _http_client is None:
+                import httpx
+                _http_client = httpx.AsyncClient(
+                    base_url=settings.ollama_base_url,
+                    timeout=60.0,
+                )
+    return _http_client
+
+
+async def embed(text: str) -> list[float]:
+    """Return a 1024-dim embedding for ``text`` via Ollama."""
+    client = await _get_http_client()
+    response = await client.post(
+        "/api/embeddings",
+        json={"model": settings.embedding_model, "prompt": text},
+    )
+    response.raise_for_status()
+    data = response.json()
+    vector = data.get("embedding")
+    if not isinstance(vector, list):
+        raise RuntimeError(f"Ollama response missing 'embedding': {data!r}")
+    return vector
+
+
+async def log_run(
+    job_name: str,
+    status: str,
+    rows_written: Optional[int],
+    error: Optional[str] = None,
+) -> None:
+    """Insert a single row into ``ingest_runs`` describing a scheduler job."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO ingest_runs (job_name, status, rows_written, error, run_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            """,
+            job_name,
+            status,
+            rows_written,
+            error,
+        )
+
+
+async def close() -> None:
+    """Release the pool and HTTP client. Safe to call multiple times."""
+    global _pool, _http_client
+    if _pool is not None:
+        await _pool.close()
+        _pool = None
+    if _http_client is not None:
+        await _http_client.aclose()
+        _http_client = None

--- a/ingestion/ner.py
+++ b/ingestion/ner.py
@@ -1,0 +1,88 @@
+"""Named-entity extraction over free text.
+
+Pulls out 4-digit Taiwan stock tickers and known wikilink vocabulary terms.
+Both lists preserve first-seen order and are de-duplicated.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from .config import settings
+
+_TICKER_RE = re.compile(r"\b\d{4}\b")
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def _wikilinks_path(repo_root: Optional[Path]) -> Path:
+    return (repo_root or settings.repo_root) / "WIKILINKS.md"
+
+
+@lru_cache(maxsize=4)
+def _load_vocab_cached(root_str: str) -> frozenset[str]:
+    root = Path(root_str) if root_str else None
+    path = _wikilinks_path(root)
+    if not path.is_file():
+        return frozenset()
+    text = path.read_text(encoding="utf-8")
+    return frozenset(_WIKILINK_RE.findall(text))
+
+
+def load_wikilink_vocab(repo_root: Optional[Path] = None) -> set[str]:
+    """Return the set of all wikilink terms found in ``WIKILINKS.md``."""
+    key = str(repo_root) if repo_root else ""
+    return set(_load_vocab_cached(key))
+
+
+def _unique_in_order(items):
+    seen: set = set()
+    result: list = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def extract(
+    text: str,
+    *,
+    ticker_set: Optional[set[str]] = None,
+    wikilink_vocab: Optional[set[str]] = None,
+) -> dict[str, list[str]]:
+    """Extract tickers and wikilink vocab terms from ``text``.
+
+    - ``tickers``: 4-digit runs, filtered by ``ticker_set`` when provided.
+    - ``wikilinks``: substring matches (case-sensitive) of every term in
+      ``wikilink_vocab``; if no vocab is given, returns terms already
+      wrapped in ``[[...]]`` inside the text.
+    """
+    tickers_raw = _TICKER_RE.findall(text or "")
+    if ticker_set is not None:
+        tickers_raw = [t for t in tickers_raw if t in ticker_set]
+    tickers = _unique_in_order(tickers_raw)
+
+    if wikilink_vocab is None:
+        wikilinks = _unique_in_order(_WIKILINK_RE.findall(text or ""))
+    else:
+        # Check longer terms first so "ABF 載板" wins over "ABF" when both match.
+        ordered_terms = sorted(wikilink_vocab, key=len, reverse=True)
+        hits: list[tuple[int, str]] = []
+        for term in ordered_terms:
+            if not term:
+                continue
+            start = 0
+            while True:
+                idx = text.find(term, start)
+                if idx == -1:
+                    break
+                hits.append((idx, term))
+                start = idx + len(term)
+        hits.sort(key=lambda pair: pair[0])
+        wikilinks = _unique_in_order(term for _, term in hits)
+
+    return {"tickers": tickers, "wikilinks": wikilinks}

--- a/ingestion/scheduler.py
+++ b/ingestion/scheduler.py
@@ -1,0 +1,134 @@
+"""APScheduler entry point for ingestion collectors.
+
+Other workers extend ``JOBS`` with ``{"job_name": ("cron expr", callable)}``
+entries. Every job is wrapped so it logs its outcome (and row count, if the
+callable returns an ``int``) to the ``ingest_runs`` table.
+
+CLI:
+    python -m ingestion.scheduler --dry-run
+    python -m ingestion.scheduler --run-once <job_name>
+    python -m ingestion.scheduler        # blocking run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import logging
+import signal
+import sys
+from typing import Awaitable, Callable, Dict, Tuple, Union
+
+from . import db
+from .config import settings
+
+logger = logging.getLogger("ingestion.scheduler")
+
+# Each entry maps a job name → (cron expression, callable). Callables may be
+# sync or async. If they return an int it is recorded as ``rows_written``.
+JobCallable = Callable[[], Union[int, None, Awaitable[Union[int, None]]]]
+JOBS: Dict[str, Tuple[str, JobCallable]] = {}
+
+
+async def _invoke(func: JobCallable):
+    result = func()
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+async def _run_job_async(name: str, func: JobCallable) -> None:
+    try:
+        result = await _invoke(func)
+        rows = result if isinstance(result, int) else None
+        await db.log_run(name, "success", rows)
+        logger.info("job %s ok (rows=%s)", name, rows)
+    except Exception as exc:  # noqa: BLE001 — we want every failure logged
+        logger.exception("job %s failed", name)
+        try:
+            await db.log_run(name, "error", None, error=str(exc))
+        except Exception:  # pragma: no cover — logging failure path
+            logger.exception("failed to log error for job %s", name)
+
+
+def _make_wrapper(name: str, func: JobCallable) -> Callable[[], None]:
+    def wrapper() -> None:
+        asyncio.run(_run_job_async(name, func))
+    wrapper.__name__ = f"wrapped_{name}"
+    return wrapper
+
+
+def build_scheduler():
+    """Build a BlockingScheduler with every registered job attached."""
+    from apscheduler.schedulers.blocking import BlockingScheduler
+    from apscheduler.triggers.cron import CronTrigger
+
+    scheduler = BlockingScheduler(timezone=settings.tz)
+    for name, (cron_expr, func) in JOBS.items():
+        trigger = CronTrigger.from_crontab(cron_expr, timezone=settings.tz)
+        scheduler.add_job(_make_wrapper(name, func), trigger=trigger, id=name, name=name)
+    return scheduler
+
+
+def _print_jobs() -> None:
+    if not JOBS:
+        print("No jobs registered.")
+        return
+    print(f"Registered jobs ({len(JOBS)}):")
+    for name, (cron_expr, _) in sorted(JOBS.items()):
+        print(f"  {name:<32} {cron_expr}")
+
+
+def _run_once(job_name: str) -> int:
+    if job_name not in JOBS:
+        print(f"error: job {job_name!r} not registered", file=sys.stderr)
+        return 2
+    _, func = JOBS[job_name]
+
+    async def _go() -> None:
+        try:
+            await _run_job_async(job_name, func)
+        finally:
+            await db.close()
+
+    asyncio.run(_go())
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(prog="ingestion.scheduler")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run", action="store_true", help="List registered jobs and exit.")
+    group.add_argument("--run-once", metavar="JOB_NAME", help="Run a single job once and exit.")
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        _print_jobs()
+        return 0
+
+    if args.run_once:
+        return _run_once(args.run_once)
+
+    scheduler = build_scheduler()
+
+    def _graceful_shutdown(*_ignored):
+        logger.info("shutdown signal received")
+        scheduler.shutdown(wait=False)
+
+    signal.signal(signal.SIGINT, _graceful_shutdown)
+    signal.signal(signal.SIGTERM, _graceful_shutdown)
+
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+    finally:
+        asyncio.run(db.close())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ingestion/test_shared.py
+++ b/ingestion/test_shared.py
@@ -1,0 +1,103 @@
+"""Smoke tests for the ingestion shared infrastructure."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ingestion import ner, universe
+from ingestion.config import Settings, settings
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_settings_loads_with_defaults():
+    s = Settings()
+    assert s.embedding_model == "bge-m3"
+    assert s.embedding_dim == 1024
+    assert s.tz == "Asia/Taipei"
+    assert s.ollama_base_url.startswith("http")
+    assert Path(s.repo_root).exists()
+
+
+def test_settings_reads_env(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_MODEL", "custom-model")
+    monkeypatch.setenv("EMBEDDING_DIM", "2048")
+    s = Settings()
+    assert s.embedding_model == "custom-model"
+    assert s.embedding_dim == 2048
+
+
+def test_electronics_tickers_size():
+    tickers = universe.electronics_tickers()
+    assert len(tickers) >= 900, f"expected 900+ electronics tickers, got {len(tickers)}"
+    assert all(t.isdigit() and len(t) == 4 for t in tickers)
+
+
+def test_electronics_tickers_includes_known():
+    tickers = universe.electronics_tickers()
+    for expected in ("2330", "2317", "2454", "2303"):
+        assert expected in tickers, f"expected {expected} in electronics universe"
+
+
+def test_ticker_to_name_matches_filename():
+    mapping = universe.ticker_to_name()
+    assert mapping.get("2330") == "台積電"
+    assert mapping.get("2454") == "聯發科"
+    assert len(mapping) == len(universe.electronics_tickers())
+
+
+def test_ner_extract_basic_shape():
+    text = "台積電 2330 進軍 [[CoWoS]] 與 HBM 產業。聯發科 2454 推出新款 MCU。"
+    result = ner.extract(
+        text,
+        ticker_set=universe.electronics_tickers(),
+        wikilink_vocab=ner.load_wikilink_vocab(),
+    )
+    assert set(result.keys()) == {"tickers", "wikilinks"}
+    assert result["tickers"] == ["2330", "2454"]
+    # CoWoS is in WIKILINKS.md, so it must appear.
+    assert "CoWoS" in result["wikilinks"]
+
+
+def test_ner_extract_filters_unknown_tickers():
+    # 9999 is not an electronics ticker and must be filtered out.
+    text = "9999 not valid, 2330 is valid."
+    result = ner.extract(text, ticker_set=universe.electronics_tickers())
+    assert "2330" in result["tickers"]
+    assert "9999" not in result["tickers"]
+
+
+def test_ner_extract_preserves_first_seen_order():
+    text = "2454 2330 2454 2330"
+    result = ner.extract(text, ticker_set=universe.electronics_tickers())
+    assert result["tickers"] == ["2454", "2330"]
+
+
+def test_ner_extract_without_vocab_uses_bracketed_links():
+    text = "投資 [[Apple]] 與 [[台積電]] 供應鏈。"
+    result = ner.extract(text, ticker_set=set())
+    assert result["wikilinks"] == ["Apple", "台積電"]
+
+
+def test_load_wikilink_vocab_nonempty():
+    vocab = ner.load_wikilink_vocab()
+    assert len(vocab) > 0
+    assert "CoWoS" in vocab
+
+
+def test_scheduler_dry_run_exits_cleanly():
+    # Run as a subprocess so argparse runs exactly as in production.
+    proc = subprocess.run(
+        [sys.executable, "-m", "ingestion.scheduler", "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stderr
+    # Either "No jobs registered" (initial state) or "Registered jobs" header.
+    assert "jobs" in proc.stdout.lower() or "registered" in proc.stdout.lower()

--- a/ingestion/universe.py
+++ b/ingestion/universe.py
@@ -1,0 +1,74 @@
+"""Electronics ticker universe extracted from Pilot_Reports filenames.
+
+Each report is stored at ``Pilot_Reports/<Sector>/<Ticker>_<ChineseName>.md``.
+We treat the filename as ground truth (see project rule #2) and derive both
+the ticker set and the ticker→name map from it.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from .config import settings
+
+# Sectors that make up the Taiwan electronics supply chain. Sum of file counts
+# across these folders is ~923, matching the project's ~926 target.
+ELECTRONICS_SECTORS = frozenset({
+    "Semiconductors",
+    "Semiconductor Equipment & Materials",
+    "Electronic Components",
+    "Computer Hardware",
+    "Communication Equipment",
+    "Consumer Electronics",
+    "Electronics & Computer Distribution",
+    "Electronic Gaming & Multimedia",
+    "Electrical Equipment & Parts",
+    "Solar",
+    "Specialty Industrial Machinery",
+    "Scientific & Technical Instruments",
+})
+
+_FILENAME_RE = re.compile(r"^(\d{4})_(.+)\.md$")
+
+
+def _reports_dir(repo_root: Optional[Path]) -> Path:
+    return (repo_root or settings.repo_root) / "Pilot_Reports"
+
+
+def _iter_electronics_files(repo_root: Optional[Path]):
+    base = _reports_dir(repo_root)
+    for sector in ELECTRONICS_SECTORS:
+        sector_dir = base / sector
+        if not sector_dir.is_dir():
+            continue
+        for path in sector_dir.iterdir():
+            if path.suffix == ".md":
+                yield path
+
+
+@lru_cache(maxsize=4)
+def _scan_cached(root_str: str) -> dict[str, str]:
+    root = Path(root_str) if root_str else None
+    result: dict[str, str] = {}
+    for path in _iter_electronics_files(root):
+        match = _FILENAME_RE.match(path.name)
+        if match:
+            ticker, name = match.group(1), match.group(2)
+            # First-write-wins if a ticker somehow appears twice.
+            result.setdefault(ticker, name)
+    return result
+
+
+def electronics_tickers(repo_root: Optional[Path] = None) -> set[str]:
+    """Return the set of 4-digit electronics tickers (~926 items)."""
+    key = str(repo_root) if repo_root else ""
+    return set(_scan_cached(key).keys())
+
+
+def ticker_to_name(repo_root: Optional[Path] = None) -> dict[str, str]:
+    """Return ``{"2330": "台積電", ...}`` for every electronics ticker."""
+    key = str(repo_root) if repo_root else ""
+    return dict(_scan_cached(key))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,8 @@ yfinance>=0.2.0
 pandas>=2.0.0
 tabulate>=0.9.0
 
-# ingestion migrations (Unit 1)
+# Unit 1 — Postgres migrations + Unit 2 — ingestion shared infra
 asyncpg>=0.29
+httpx>=0.27
+apscheduler>=3.10
+pydantic-settings>=2.0


### PR DESCRIPTION
## Summary
- Adds `ingestion/` package providing shared infrastructure every collector will depend on (Unit 2 of 9).
- `config` (env-backed Settings), `db` (asyncpg pool + Ollama `bge-m3` embeddings + `ingest_runs` logger), `universe` (~921 electronics tickers from `Pilot_Reports/`), `ner` (ticker + wikilink vocab extraction, longest-match first), `scheduler` (APScheduler with `--dry-run` / `--run-once` CLI and a pluggable `JOBS` registry).
- Adds four deps to `requirements.txt` under a `# Unit 2 — ingestion shared infra` header.
- Does **not** create `ingestion/__init__.py` or `ingestion/migrations/` (Unit 1's scope) and does **not** add collectors (separate workers).

## Test plan
- [x] `python3 -m pytest ingestion/test_shared.py -v` — 11/11 passing
- [x] `python3 -c "from ingestion.universe import electronics_tickers; s = electronics_tickers(); print(len(s), sorted(s)[:5])"` — `921 ['1471', '1503', '1504', '1513', '1514']`
- [x] `python3 -c "from ingestion.ner import extract, load_wikilink_vocab; from ingestion.universe import electronics_tickers; print(extract('台積電 2330 進軍 [[CoWoS]] 與 HBM 產業。聯發科 2454 推出新款 MCU。', ticker_set=electronics_tickers(), wikilink_vocab=load_wikilink_vocab()))"` — tickers=['2330','2454'], wikilinks include CoWoS/HBM/MCU/台積電/聯發科
- [x] `python3 -m ingestion.scheduler --dry-run` — prints "No jobs registered." and exits 0

## Notes
- `db.embed()` and `db.log_run()` require Ollama + Postgres to be running at call time; this unit's own tests do not hit either service, so the companion systems are only exercised when a collector (separate worker) runs.
- The scheduler's `JOBS` dict is intentionally empty; collectors extend it via `from ingestion.scheduler import JOBS; JOBS["name"] = ("cron", callable)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)