### PR TITLE
Unit 4: RSS collectors (CNA/UDN/CTEE)

### DIFF
--- a/ingestion/collectors/_rss_base.py
+++ b/ingestion/collectors/_rss_base.py
@@ -1,0 +1,171 @@
+"""Shared RSS collector logic.
+
+Thin wrappers in ``rss_cna.py`` / ``rss_udn.py`` / ``rss_ctee.py`` call
+``ingest_rss(source, feed_url, dry_run=..., limit=...)`` which:
+
+1. Fetches the feed (httpx) and parses it (feedparser).
+2. For each entry, runs NER over ``title + body`` and skips entries with zero
+   tickers AND zero wikilinks.
+3. Embeds ``title + body[:2000]`` via ``ingestion.db.embed`` (NULL on error).
+4. INSERTs into ``news_items`` with ``ON CONFLICT (source_url) DO NOTHING``.
+5. Calls ``log_run(source, status, rows_written)``.
+
+CLI helper ``build_arg_parser`` wires ``--dry-run / --limit / --url``.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from calendar import timegm
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+import feedparser
+import httpx
+
+from .. import db, ner
+
+INSERT_SQL = """
+INSERT INTO news_items (source, source_url, published_at, title, body, tickers, wikilinks, embedding)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector)
+ON CONFLICT (source_url) DO NOTHING
+"""
+
+HTTP_TIMEOUT = 20.0
+# Browser-like UA: some sources (e.g. CTEE behind Cloudflare) 403 bot-shaped UAs.
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+EMBED_BODY_LIMIT = 2000
+
+
+def build_arg_parser(source: str, default_url: str) -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=f"RSS collector for {source}")
+    p.add_argument("--dry-run", action="store_true", help="Parse & report only, no DB write")
+    p.add_argument("--limit", type=int, default=50, help="Max items to process")
+    p.add_argument("--url", default=default_url, help="Override feed URL (for testing)")
+    return p
+
+
+def _parse_published_at(entry) -> datetime:
+    struct = getattr(entry, "published_parsed", None) or getattr(entry, "updated_parsed", None)
+    if struct is not None:
+        return datetime.fromtimestamp(timegm(struct), tz=timezone.utc)
+    return datetime.now(tz=timezone.utc)
+
+
+def _extract_body(entry) -> str:
+    content = getattr(entry, "content", None)
+    if content:
+        try:
+            return content[0].get("value", "") or ""
+        except (AttributeError, IndexError, TypeError):
+            pass
+    return getattr(entry, "summary", "") or getattr(entry, "description", "") or ""
+
+
+async def _fetch_feed_bytes(url: str) -> bytes:
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT, headers={"User-Agent": USER_AGENT}) as client:
+        resp = await client.get(url, follow_redirects=True)
+        resp.raise_for_status()
+        return resp.content
+
+
+def parse_feed(raw: bytes) -> Iterable[dict]:
+    """Parse feed bytes and yield normalized row dicts (without embedding/DB work)."""
+    parsed = feedparser.parse(raw)
+    for entry in parsed.entries:
+        title = (getattr(entry, "title", "") or "").strip()
+        if not title:
+            continue
+        source_url = (getattr(entry, "link", "") or "").strip()
+        if not source_url:
+            continue
+        body = _extract_body(entry)
+        text = f"{title}\n{body}"
+        ner_result = ner.extract(text)
+        yield {
+            "title": title,
+            "body": body,
+            "source_url": source_url,
+            "published_at": _parse_published_at(entry),
+            "tickers": ner_result.tickers,
+            "wikilinks": ner_result.wikilinks,
+        }
+
+
+async def _embed_or_none(text: str) -> Optional[list[float]]:
+    try:
+        return await db.embed(text)
+    except Exception as exc:
+        print(f"[embed] failed, inserting NULL: {exc}", file=sys.stderr)
+        return None
+
+
+async def ingest_rss(source: str, feed_url: str, *, dry_run: bool, limit: int) -> int:
+    """Fetch, filter, embed, insert. Returns rows_written (0 on dry-run)."""
+    try:
+        raw = await _fetch_feed_bytes(feed_url)
+    except Exception as exc:
+        print(f"[fetch] {source} failed: {exc}", file=sys.stderr)
+        if not dry_run:
+            await db.log_run(source, "error", 0)
+        return 0
+
+    relevant: list[dict] = []
+    skipped = 0
+    for row in parse_feed(raw):
+        if limit and len(relevant) >= limit:
+            break
+        if not row["tickers"] and not row["wikilinks"]:
+            skipped += 1
+            continue
+        relevant.append(row)
+
+    print(
+        f"[{source}] parsed: kept={len(relevant)} skipped_no_match={skipped} limit={limit}",
+        file=sys.stderr,
+    )
+
+    if dry_run:
+        for r in relevant:
+            print(
+                f"- {r['published_at'].isoformat()} | tickers={r['tickers']} wikilinks={r['wikilinks']} | {r['title']}\n  {r['source_url']}"
+            )
+        return 0
+
+    rows_written = 0
+    try:
+        pool = await db.get_pool()
+        async with pool.acquire() as conn:
+            for row in relevant:
+                embedding = await _embed_or_none(row["title"] + "\n" + row["body"][:EMBED_BODY_LIMIT])
+                result = await conn.execute(
+                    INSERT_SQL,
+                    source,
+                    row["source_url"],
+                    row["published_at"],
+                    row["title"],
+                    row["body"],
+                    row["tickers"],
+                    row["wikilinks"],
+                    db.vector_literal(embedding),
+                )
+                # asyncpg returns "INSERT 0 N" — 0 when ON CONFLICT skipped.
+                if result.endswith(" 1"):
+                    rows_written += 1
+        await db.log_run(source, "ok", rows_written)
+    except Exception as exc:
+        print(f"[{source}] DB error: {exc}", file=sys.stderr)
+        await db.log_run(source, "error", rows_written)
+        raise
+
+    print(f"[{source}] inserted={rows_written}", file=sys.stderr)
+    return rows_written
+
+
+def run_cli(source: str, default_url: str) -> None:
+    args = build_arg_parser(source, default_url).parse_args()
+    asyncio.run(ingest_rss(source, args.url, dry_run=args.dry_run, limit=args.limit))

--- a/ingestion/collectors/fixtures/rss_sample.xml
+++ b/ingestion/collectors/fixtures/rss_sample.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Sample TW Electronics Feed</title>
+    <link>https://example.com/</link>
+    <description>Fixture for unit tests</description>
+    <item>
+      <title>台積電 2330 擴大 CoWoS 產能，HBM 需求強勁</title>
+      <link>https://example.com/news/1</link>
+      <pubDate>Mon, 21 Apr 2026 06:00:00 GMT</pubDate>
+      <description><![CDATA[台積電 (2330) 宣布擴大 CoWoS 封裝產能，回應 NVIDIA 與 AMD 對 HBM 配套的強勁需求。]]></description>
+      <content:encoded><![CDATA[<p>台積電 (2330) 宣布擴大 CoWoS 封裝產能，回應 [[NVIDIA]] 與 AMD 對 HBM 配套的強勁需求。</p>]]></content:encoded>
+    </item>
+    <item>
+      <title>今日天氣晴朗適合出遊</title>
+      <link>https://example.com/news/2</link>
+      <pubDate>Mon, 21 Apr 2026 07:00:00 GMT</pubDate>
+      <description><![CDATA[今天全台氣溫回升，是踏青好天氣。]]></description>
+    </item>
+    <item>
+      <title>聯發科發表新 5G 晶片</title>
+      <link>https://example.com/news/3</link>
+      <pubDate>Mon, 21 Apr 2026 08:00:00 GMT</pubDate>
+      <description><![CDATA[聯發科 (2454) 宣布新款 5G 基頻晶片，採用 MediaTek 自研架構。]]></description>
+    </item>
+  </channel>
+</rss>

--- a/ingestion/collectors/rss_cna.py
+++ b/ingestion/collectors/rss_cna.py
@@ -1,0 +1,15 @@
+"""中央社 (CNA) financial RSS collector.
+
+Feed: https://feeds.feedburner.com/rsscna/finance
+Run:  python3 -m ingestion.collectors.rss_cna --dry-run --limit 20
+"""
+from __future__ import annotations
+
+from ._rss_base import run_cli
+
+SOURCE = "cna"
+FEED_URL = "https://feeds.feedburner.com/rsscna/finance"
+
+
+if __name__ == "__main__":
+    run_cli(SOURCE, FEED_URL)

--- a/ingestion/collectors/rss_ctee.py
+++ b/ingestion/collectors/rss_ctee.py
@@ -1,0 +1,17 @@
+"""工商時報 (CTEE) tech/industry RSS collector.
+
+Feed: https://www.ctee.com.tw/feed
+  NOTE: CTEE sits behind Cloudflare WAF and may return 403 for non-browser
+  clients. Override with ``--url`` or set a browser-like UA upstream if needed.
+Run:  python3 -m ingestion.collectors.rss_ctee --dry-run --limit 20
+"""
+from __future__ import annotations
+
+from ._rss_base import run_cli
+
+SOURCE = "ctee"
+FEED_URL = "https://www.ctee.com.tw/feed"
+
+
+if __name__ == "__main__":
+    run_cli(SOURCE, FEED_URL)

--- a/ingestion/collectors/rss_udn.py
+++ b/ingestion/collectors/rss_udn.py
@@ -1,0 +1,16 @@
+"""經濟日報 (UDN Money) industry/tech RSS collector.
+
+Feed: https://money.udn.com/rssfeed/news/1001/5591
+  (category: 產業科技 — industry & tech, closest fit for electronics coverage)
+Run:  python3 -m ingestion.collectors.rss_udn --dry-run --limit 20
+"""
+from __future__ import annotations
+
+from ._rss_base import run_cli
+
+SOURCE = "udn"
+FEED_URL = "https://money.udn.com/rssfeed/news/1001/5591"
+
+
+if __name__ == "__main__":
+    run_cli(SOURCE, FEED_URL)

--- a/ingestion/collectors/test_rss.py
+++ b/ingestion/collectors/test_rss.py
@@ -1,0 +1,88 @@
+"""Unit tests for RSS parsing + NER path (no DB, no network)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ingestion import ner
+from ingestion.collectors import _rss_base
+
+FIXTURE = Path(__file__).parent / "fixtures" / "rss_sample.xml"
+
+
+def test_fixture_exists():
+    assert FIXTURE.exists(), f"Fixture missing: {FIXTURE}"
+
+
+def test_parse_feed_yields_entries():
+    rows = list(_rss_base.parse_feed(FIXTURE.read_bytes()))
+    assert len(rows) == 3
+    urls = [r["source_url"] for r in rows]
+    assert urls == [
+        "https://example.com/news/1",
+        "https://example.com/news/2",
+        "https://example.com/news/3",
+    ]
+
+
+def test_parse_feed_extracts_tickers_and_wikilinks():
+    rows = list(_rss_base.parse_feed(FIXTURE.read_bytes()))
+    first = rows[0]
+    assert "2330" in first["tickers"]
+    # Wikilink dict in WIKILINKS.md contains CoWoS and HBM — both appear in title.
+    assert "CoWoS" in first["wikilinks"]
+    assert "HBM" in first["wikilinks"]
+
+
+def test_parse_feed_irrelevant_entry_has_no_matches():
+    rows = list(_rss_base.parse_feed(FIXTURE.read_bytes()))
+    weather = rows[1]
+    assert weather["tickers"] == []
+    # Weather entry contains no known proper nouns from WIKILINKS.md.
+    assert weather["wikilinks"] == []
+
+
+def test_parse_feed_published_at_utc():
+    rows = list(_rss_base.parse_feed(FIXTURE.read_bytes()))
+    # pubDate is "Mon, 21 Apr 2026 06:00:00 GMT" — must parse to aware UTC.
+    published = rows[0]["published_at"]
+    assert published.tzinfo is not None
+    assert published.year == 2026 and published.month == 4 and published.day == 21
+    assert published.hour == 6
+
+
+def test_ner_ticker_regex_rejects_embedded_digits():
+    # "12345" should not yield a 4-digit ticker; "2330" standalone should.
+    assert ner.extract("code 12345 is long").tickers == []
+    assert ner.extract("see 2330").tickers == ["2330"]
+
+
+def test_ingest_rss_dry_run_no_db(monkeypatch, capsys):
+    """--dry-run path should never hit the DB."""
+    import asyncio
+
+    async def fake_fetch(url: str) -> bytes:
+        return FIXTURE.read_bytes()
+
+    monkeypatch.setattr(_rss_base, "_fetch_feed_bytes", fake_fetch)
+
+    def boom(*a, **kw):
+        raise AssertionError("dry-run must not touch db.get_pool")
+
+    from ingestion import db
+    monkeypatch.setattr(db, "get_pool", boom)
+
+    rows_written = asyncio.run(
+        _rss_base.ingest_rss("test", "http://ignored", dry_run=True, limit=10)
+    )
+    assert rows_written == 0
+    out = capsys.readouterr().out
+    # Relevant entries (1 and 3) should be printed; weather (2) filtered out.
+    assert "example.com/news/1" in out
+    assert "example.com/news/3" in out
+    assert "example.com/news/2" not in out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ asyncpg>=0.29
 httpx>=0.27
 apscheduler>=3.10
 pydantic-settings>=2.0
+
+# Unit 4 — RSS collectors
+feedparser>=6.0


### PR DESCRIPTION
## Summary

Unit 4 deliverable: three RSS collectors that pull Taiwan financial/tech news, run NER to keep only electronics-relevant items, embed with Ollama bge-m3, and write to `news_items`.

- **CNA** (中央社) — `https://feeds.feedburner.com/rsscna/finance`
- **UDN** (經濟日報 產業科技) — `https://money.udn.com/rssfeed/news/1001/5591`
- **CTEE** (工商時報) — `https://www.ctee.com.tw/feed` (see caveat below)

Each is ~15 lines; shared logic lives in `ingestion/collectors/_rss_base.py`. CLI flags: `--dry-run`, `--limit N`, `--url <override>`.

### Also included (temporary stubs)

Unit 2 hasn't been merged yet, so this PR ships minimal stubs so the collectors can import and run standalone:
- `ingestion/config.py` — reads `PG_NEWS_DSN` / `OLLAMA_URL` from env
- `ingestion/db.py` — asyncpg pool + `embed()` via Ollama bge-m3 + best-effort `log_run()`
- `ingestion/ner.py` — regex-based ticker matcher + WIKILINKS.md substring matcher

**These should be overwritten when Unit 2 lands** — there are no behavior diffs required on the collector side.

## Test plan

- [x] Unit tests: `python3 -m pytest ingestion/collectors/test_rss.py -v` — 7 passed (parse feed, extract tickers+wikilinks, skip irrelevant entries, UTC timestamps, ticker regex, dry-run does not touch DB)
- [x] Dry-run CNA — kept 17 / skipped 3 of 20
- [x] Dry-run UDN — kept 18 / skipped 2 of 20
- [x] Dry-run CTEE — feed returns 403 (Cloudflare WAF blocks non-browser-origin traffic; collector reports error cleanly and exits 0 — Unit 5/3 will encounter the same Cloudflare issue)
- [x] Live write against `knowledge-platform-postgres-1` with Ollama bge-m3:
  ```
  PG_NEWS_DSN=postgresql://knowledge:knowledge@localhost:5433/tw_electronics_u4 \
    python3 -m ingestion.collectors.rss_cna --limit 5
  ```
  Result: 5 rows inserted, all with populated tickers, wikilinks, and 1024-dim embedding (`embedding IS NOT NULL = t`).

## Notes / caveats

1. **CTEE Cloudflare WAF** — All paths under `ctee.com.tw` return 403 from curl/Python with any UA. Recommend either (a) running the collector from an IP whitelisted by CTEE, or (b) switching to a web-scraper strategy outside RSS scope. For now the collector is wired up and fails cleanly; switching feed URL via `--url` is a one-liner.
2. **NER stub noise** — The substring-based stub occasionally matches city names (`台北`, `新竹`) because they appear in `WIKILINKS.md` as company-name prefixes. Unit 2's real NER will fix this without collector changes.
3. **No collector_runs table** — When the table doesn't exist, `log_run()` prints to stdout instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)