### PR TITLE
Unit 8: Docker scheduler container

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,9 @@
+TZ=Asia/Taipei
+PG_NEWS_DSN=postgresql://knowledge:knowledge@host.docker.internal:5433/tw_electronics
+PG_TRADING_DSN=postgresql://tmf:tmf_dev_2026@host.docker.internal:5432/tmf_market_data
+FALKORDB_HOST=host.docker.internal
+FALKORDB_PORT=6380
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+EMBEDDING_MODEL=bge-m3
+GRAPHITI_GROUP_ID=tw-electronics
+FINMIND_TOKEN=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    TZ=Asia/Taipei
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tzdata ca-certificates \
+ && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash scheduler
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+# Application code (ingestion/, graph/, scripts/utils.py) is provided at
+# runtime via the bind mount declared in docker-compose.yml (../:/app:ro).
+# This keeps the build context tight and lets the container start even
+# before sibling Units have merged their modules into the repo.
+
+RUN mkdir -p /app/ingestion /app/graph /app/scripts \
+ && chown -R scheduler:scheduler /app
+
+USER scheduler
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python3 -c "import asyncpg" || exit 1
+
+ENTRYPOINT ["python3", "-u", "-m", "ingestion.scheduler"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,51 @@
+# TW Electronics Scheduler (Docker)
+
+Long-running APScheduler container that runs `ingestion.scheduler` as a background worker.
+Talks to companion services on the host via `host.docker.internal`.
+
+## Prerequisites
+Companion services already running on host:
+- Postgres (news) @ `localhost:5433`
+- Postgres (trading/TimescaleDB) @ `localhost:5432`
+- FalkorDB @ `localhost:6380`
+- Ollama @ `localhost:11434`
+
+## Setup
+```bash
+cp docker/.env.example docker/.env
+# edit docker/.env — set FINMIND_TOKEN and verify DSNs
+```
+
+## Build
+```bash
+docker compose -f docker/docker-compose.yml --env-file docker/.env build
+```
+
+## Run (detached)
+```bash
+docker compose -f docker/docker-compose.yml --env-file docker/.env up -d
+```
+
+## Logs
+APScheduler logs to stdout; follow with:
+```bash
+docker logs -f tw-electronics-scheduler
+```
+
+## Stop
+```bash
+docker compose -f docker/docker-compose.yml --env-file docker/.env down
+```
+
+## Notes
+- The repo is bind-mounted read-only at `/app` for live code reload during development.
+- The container exposes no ports (background worker only).
+- Runs as non-root user `scheduler`.
+- Application code (`ingestion/`, `graph/`, `scripts/utils.py`) is provided via the bind mount at runtime, not baked into the image. This lets the image build before sibling Units have merged. If the container logs `ModuleNotFoundError: No module named 'ingestion'`, it means Unit 2's `ingestion/scheduler.py` has not landed on your branch yet.
+- Any extra Python deps required by `ingestion.scheduler` (e.g., `apscheduler`, `asyncpg`, `redis`) must be added to the root `requirements.txt` by the unit that introduces them.
+
+## Config validation
+```bash
+bash docker/test_config.sh
+```
+Renders compose config and greps for the expected service, env keys, and mount — useful as a quick smoke test before building.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  tw-electronics-scheduler:
+    container_name: tw-electronics-scheduler
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    env_file:
+      - .env
+    environment:
+      TZ: ${TZ:-Asia/Taipei}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ..:/app:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import asyncpg"]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3

--- a/docker/test_config.sh
+++ b/docker/test_config.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Validates docker-compose.yml by rendering it with `docker compose config`
+# and checking that the expected service and env keys are present.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "INFO: $ENV_FILE not found; using .env.example for config validation"
+    ENV_FILE="$SCRIPT_DIR/.env.example"
+fi
+
+RENDERED="$(docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" config)"
+
+fail=0
+check() {
+    local pattern="$1"
+    local label="$2"
+    if grep -q "$pattern" <<<"$RENDERED"; then
+        echo "OK   $label"
+    else
+        echo "MISS $label (pattern: $pattern)"
+        fail=1
+    fi
+}
+
+check "tw-electronics-scheduler:" "service tw-electronics-scheduler"
+check "host.docker.internal[:=]host-gateway" "extra_hosts host-gateway"
+check "TZ:" "env TZ"
+check "PG_NEWS_DSN:" "env PG_NEWS_DSN"
+check "PG_TRADING_DSN:" "env PG_TRADING_DSN"
+check "FALKORDB_HOST:" "env FALKORDB_HOST"
+check "FALKORDB_PORT:" "env FALKORDB_PORT"
+check "OLLAMA_BASE_URL:" "env OLLAMA_BASE_URL"
+check "EMBEDDING_MODEL:" "env EMBEDDING_MODEL"
+check "GRAPHITI_GROUP_ID:" "env GRAPHITI_GROUP_ID"
+check "FINMIND_TOKEN:" "env FINMIND_TOKEN"
+check "restart: unless-stopped" "restart policy"
+check "read_only: true" "read-only repo mount"
+
+if [[ $fail -ne 0 ]]; then
+    echo "FAIL: docker-compose config missing expected keys"
+    exit 1
+fi
+echo "PASS: docker-compose config looks good"


### PR DESCRIPTION
## Summary
- Adds `docker/` standalone stack that packages `ingestion.scheduler` (Unit 2) as a long-running APScheduler container.
- Non-root user, healthcheck via `asyncpg`, `host.docker.internal:host-gateway` for reaching host-side Postgres / FalkorDB / Ollama, `restart: unless-stopped`, read-only bind mount of the repo at `/app` for live reload.
- Application code (`ingestion/`, `graph/`, `scripts/utils.py`) is provided by the bind mount at runtime rather than `COPY`'d at build time — keeps the image build green before sibling Units have merged.

## Files added
- `docker/Dockerfile` — python:3.11-slim base, installs `requirements.txt`, creates `scheduler` user.
- `docker/docker-compose.yml` — single `tw-electronics-scheduler` service.
- `docker/.env.example` — all env vars with placeholders.
- `docker/test_config.sh` — renders `docker compose config` and greps for expected service/env/mount keys.
- `docker/README.md` — build/run/logs instructions and runtime-bind-mount explanation.

## Test plan
- [x] `bash docker/test_config.sh` — all 13 checks pass
- [x] `docker compose -f docker/docker-compose.yml --env-file docker/.env build` — image built successfully
- [x] `docker compose ... up -d` — container starts; logs expected `ModuleNotFoundError: No module named 'ingestion'` until Unit 2 merges
- [x] `docker compose ... down` — clean teardown
- [ ] Post-merge of Unit 2: container should log APScheduler startup with registered jobs

## Notes
- No changes to `requirements.txt`, `ingestion/`, `graph/`, `mcp_server/`, `Pilot_Reports/`, or root-level docs.
- Any extra Python deps needed by `ingestion.scheduler` (apscheduler, asyncpg, redis, etc.) must be added by the unit that introduces them.