### PR TITLE
Unit 5: Search + fundamentals collectors (Yahoo/Google News/FinMind)

### DIFF
--- a/ingestion/collectors/_common.py
+++ b/ingestion/collectors/_common.py
@@ -1,0 +1,149 @@
+"""Shared helpers for Unit 5 collectors.
+
+Kept tiny on purpose: relative-time parsing, news_items upsert, and the
+per-ticker driver that Yahoo/Google share.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Iterable
+
+import asyncpg
+import httpx
+
+from ..config import USER_AGENT
+from ..db import close_pool, get_pool
+
+_REL_UNITS = {
+    "秒": "seconds", "分鐘": "minutes", "分": "minutes",
+    "小時": "hours", "天": "days", "日": "days", "週": "weeks", "周": "weeks",
+    "month": "months_approx", "月": "months_approx",
+    "year": "years_approx", "年": "years_approx",
+}
+
+_REL_RE = re.compile(
+    r"(?P<num>\d+)\s*(?P<unit>秒|分鐘|分|小時|天|日|週|周|月|年|"
+    r"seconds?|minutes?|mins?|hours?|hrs?|days?|weeks?|months?|years?)\s*(?:前|ago)?",
+    re.IGNORECASE,
+)
+
+
+def parse_relative_time(text: str, *, now: datetime | None = None) -> datetime | None:
+    """Normalize strings like '3小時前' or '2 days ago' to a UTC datetime.
+
+    Returns None if the string can't be parsed — callers should fall back to
+    their source's absolute timestamp field.
+    """
+    if not text:
+        return None
+    now = now or datetime.now(timezone.utc)
+    text = text.strip()
+
+    try:
+        # ISO/RFC dates — pandas-free parse via fromisoformat; callers can also
+        # pass a feedparser-provided struct_time and bypass this helper.
+        if "T" in text or re.match(r"^\d{4}-\d{2}-\d{2}", text):
+            return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+
+    m = _REL_RE.search(text)
+    if not m:
+        return None
+    num = int(m.group("num"))
+    unit = m.group("unit").lower()
+
+    # Map English plurals/shorthand onto the Chinese table above.
+    english = {
+        "second": "seconds", "seconds": "seconds",
+        "min": "minutes", "mins": "minutes", "minute": "minutes", "minutes": "minutes",
+        "hour": "hours", "hours": "hours", "hr": "hours", "hrs": "hours",
+        "day": "days", "days": "days",
+        "week": "weeks", "weeks": "weeks",
+        "month": "months_approx", "months": "months_approx",
+        "year": "years_approx", "years": "years_approx",
+    }
+    kind = english.get(unit) or _REL_UNITS.get(unit)
+    if kind is None:
+        return None
+
+    if kind == "months_approx":
+        return now - timedelta(days=30 * num)
+    if kind == "years_approx":
+        return now - timedelta(days=365 * num)
+    return now - timedelta(**{kind: num})
+
+
+INSERT_NEWS_SQL = """
+INSERT INTO news_items (source, source_url, published_at, title, body, tickers, wikilinks)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (source_url) DO NOTHING
+"""
+
+
+async def insert_news_rows(
+    pool: asyncpg.Pool,
+    source: str,
+    rows: Iterable[dict],
+) -> int:
+    """Bulk-insert parsed news rows. Returns the input count (asyncpg's
+    executemany can't distinguish inserted vs. skipped on ON CONFLICT)."""
+    rows = list(rows)
+    if not rows:
+        return 0
+    async with pool.acquire() as conn:
+        await conn.executemany(
+            INSERT_NEWS_SQL,
+            [
+                (
+                    source,
+                    r["source_url"],
+                    r["published_at"],
+                    r["title"],
+                    r.get("body") or "",
+                    r.get("tickers") or [],
+                    r.get("wikilinks") or [],
+                )
+                for r in rows
+            ],
+        )
+    return len(rows)
+
+
+def make_client() -> httpx.AsyncClient:
+    """Uniform httpx client config shared by all collectors."""
+    return httpx.AsyncClient(
+        headers={"User-Agent": USER_AGENT},
+        follow_redirects=True,
+        timeout=30.0,
+    )
+
+
+async def run_news_collector(
+    source: str,
+    tickers: Iterable[str],
+    collect_fn: Callable[[str, httpx.AsyncClient], Awaitable[list[Any]]],
+    *,
+    dry_run: bool,
+    format_preview: Callable[[Any], str] | None = None,
+) -> None:
+    """Driver for Yahoo/Google style news collectors.
+
+    `collect_fn(ticker, client)` must return a list of items. Each item must
+    expose `.as_row()` (for DB writes) and ideally str() nicely for dry-run.
+    """
+    preview = format_preview or (lambda it: str(it))
+    async with make_client() as client:
+        for ticker in tickers:
+            print(f"[{source}] {ticker}")
+            items = await collect_fn(ticker, client)
+            if dry_run:
+                for it in items:
+                    print(preview(it))
+                continue
+            pool = await get_pool()
+            written = await insert_news_rows(pool, source, (it.as_row() for it in items))
+            print(f"  wrote {written} rows")
+    if not dry_run:
+        await close_pool()

--- a/ingestion/collectors/finmind.py
+++ b/ingestion/collectors/finmind.py
@@ -1,0 +1,216 @@
+"""FinMind monthly-revenue collector.
+
+Fetches `TaiwanStockMonthRevenue` rows for a ticker and upserts them into
+`finmind_fundamentals`. Free tier works without a token (slower limits); set
+`FINMIND_TOKEN` for a signed request.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Iterable
+
+import httpx
+
+from ..config import FINMIND_TOKEN
+from ..db import close_pool, get_pool
+from ..universe import all_tickers
+from ._common import make_client
+
+API_URL = "https://api.finmindtrade.com/api/v4/data"
+DATASET = "TaiwanStockMonthRevenue"
+DEFAULT_SINCE = "2024-01"
+RATE_LIMIT_SLEEP = 5.0  # FinMind free tier: sleep then retry on 402/429
+
+UPSERT_SQL = """
+INSERT INTO finmind_fundamentals (ticker, report_month, monthly_revenue, yoy_pct, mom_pct)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (ticker, report_month) DO UPDATE SET
+    monthly_revenue = EXCLUDED.monthly_revenue,
+    yoy_pct = EXCLUDED.yoy_pct,
+    mom_pct = EXCLUDED.mom_pct
+"""
+
+
+@dataclass
+class RevenueRow:
+    ticker: str
+    report_month: date
+    monthly_revenue: int | None
+    yoy_pct: Decimal | None
+    mom_pct: Decimal | None
+
+
+def _to_decimal(value) -> Decimal | None:
+    if value in (None, "", "NaN"):
+        return None
+    try:
+        return Decimal(str(value))
+    except (ValueError, ArithmeticError):
+        return None
+
+
+def _to_int(value) -> int | None:
+    if value in (None, "", "NaN"):
+        return None
+    try:
+        return int(Decimal(str(value)))
+    except (ValueError, ArithmeticError):
+        return None
+
+
+def parse_rows(ticker: str, payload: dict) -> list[RevenueRow]:
+    """Normalize FinMind's `{"data": [...]}` payload to RevenueRow objects.
+
+    FinMind returns either:
+      - a `revenue_year`/`revenue_month` pair (newer), or
+      - a `date` field like `2024-07-10` (older).
+    We prefer the numeric pair when present so we always emit YYYY-MM-01.
+    Growth fields are sometimes absent on the free tier; we derive them from
+    consecutive revenue values so downstream consumers get usable numbers.
+    """
+    raw_rows: list[RevenueRow] = []
+    for item in payload.get("data", []):
+        year = item.get("revenue_year")
+        month = item.get("revenue_month")
+        if year and month:
+            report_month = date(int(year), int(month), 1)
+        elif item.get("date"):
+            parsed = date.fromisoformat(item["date"])
+            report_month = parsed.replace(day=1)
+        else:
+            continue
+        raw_rows.append(RevenueRow(
+            ticker=ticker,
+            report_month=report_month,
+            monthly_revenue=_to_int(item.get("revenue")),
+            yoy_pct=_to_decimal(item.get("revenue_year_growth") or item.get("YoY")),
+            mom_pct=_to_decimal(item.get("revenue_month_growth") or item.get("MoM")),
+        ))
+    if not raw_rows:
+        return raw_rows
+
+    raw_rows.sort(key=lambda r: r.report_month)
+    by_month = {r.report_month: r for r in raw_rows}
+
+    def _pct_change(new: int | None, old: int | None) -> Decimal | None:
+        if new is None or old is None or old == 0:
+            return None
+        return (Decimal(new) - Decimal(old)) / Decimal(old) * Decimal(100)
+
+    for row in raw_rows:
+        if row.mom_pct is None:
+            prev = by_month.get(_shift_month(row.report_month, -1))
+            if prev:
+                row.mom_pct = _pct_change(row.monthly_revenue, prev.monthly_revenue)
+        if row.yoy_pct is None:
+            prev_year = by_month.get(_shift_month(row.report_month, -12))
+            if prev_year:
+                row.yoy_pct = _pct_change(row.monthly_revenue, prev_year.monthly_revenue)
+    return raw_rows
+
+
+def _shift_month(d: date, delta: int) -> date:
+    """Return `d` shifted by `delta` calendar months, preserving day=1."""
+    month_index = d.year * 12 + (d.month - 1) + delta
+    return date(month_index // 12, month_index % 12 + 1, 1)
+
+
+async def _fetch(
+    client: httpx.AsyncClient,
+    ticker: str,
+    start_date: str,
+) -> dict:
+    params = {"dataset": DATASET, "data_id": ticker, "start_date": start_date}
+    if FINMIND_TOKEN:
+        params["token"] = FINMIND_TOKEN
+
+    for attempt in range(2):
+        resp = await client.get(API_URL, params=params)
+        if resp.status_code in (402, 429):
+            if attempt == 0:
+                print(
+                    f"  rate-limited (HTTP {resp.status_code}); sleeping {RATE_LIMIT_SLEEP}s",
+                    file=sys.stderr,
+                )
+                await asyncio.sleep(RATE_LIMIT_SLEEP)
+                continue
+            resp.raise_for_status()
+        resp.raise_for_status()
+        return resp.json()
+    return {"data": []}
+
+
+def _since_to_start_date(since: str) -> str:
+    """Accept YYYY-MM or YYYY-MM-DD; FinMind wants YYYY-MM-DD."""
+    return since if len(since) == 10 else f"{since}-01"
+
+
+async def collect(
+    ticker: str,
+    *,
+    since: str = DEFAULT_SINCE,
+    client: httpx.AsyncClient | None = None,
+) -> list[RevenueRow]:
+    own_client = client is None
+    client = client or make_client()
+    try:
+        payload = await _fetch(client, ticker, _since_to_start_date(since))
+        return parse_rows(ticker, payload)
+    finally:
+        if own_client:
+            await client.aclose()
+
+
+async def _run(tickers: Iterable[str], *, since: str, dry_run: bool) -> None:
+    async with make_client() as client:
+        for ticker in tickers:
+            print(f"[finmind] {ticker}")
+            rows = await collect(ticker, since=since, client=client)
+            if dry_run:
+                for r in rows:
+                    print(
+                        f"  {r.report_month.isoformat()}  rev={r.monthly_revenue}  "
+                        f"YoY={r.yoy_pct}  MoM={r.mom_pct}"
+                    )
+                continue
+            if not rows:
+                print("  no rows returned")
+                continue
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                await conn.executemany(
+                    UPSERT_SQL,
+                    [
+                        (r.ticker, r.report_month, r.monthly_revenue, r.yoy_pct, r.mom_pct)
+                        for r in rows
+                    ],
+                )
+            print(f"  wrote {len(rows)} rows")
+    if not dry_run:
+        await close_pool()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="FinMind monthly-revenue collector")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--ticker", help="4-digit ticker, e.g. 2330")
+    group.add_argument("--all", action="store_true", help="iterate every electronics ticker")
+    parser.add_argument("--since", default=DEFAULT_SINCE, help="YYYY-MM; default 2024-01")
+    parser.add_argument("--dry-run", action="store_true", help="parse + print; no DB write")
+    args = parser.parse_args(argv)
+
+    tickers = all_tickers() if args.all else [args.ticker]
+    if not tickers:
+        print("no tickers to process", file=sys.stderr)
+        return 1
+    asyncio.run(_run(tickers, since=args.since, dry_run=args.dry_run))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ingestion/collectors/fixtures/finmind_2330.json
+++ b/ingestion/collectors/fixtures/finmind_2330.json
@@ -1,0 +1,46 @@
+{
+  "msg": "success",
+  "status": 200,
+  "data": [
+    {
+      "date": "2024-01-10",
+      "stock_id": "2330",
+      "country": "Taiwan",
+      "revenue": 215793000000,
+      "revenue_month": 1,
+      "revenue_year": 2024,
+      "revenue_month_growth": -5.34,
+      "revenue_year_growth": 7.88
+    },
+    {
+      "date": "2024-02-10",
+      "stock_id": "2330",
+      "country": "Taiwan",
+      "revenue": 181631000000,
+      "revenue_month": 2,
+      "revenue_year": 2024,
+      "revenue_month_growth": -15.83,
+      "revenue_year_growth": 11.21
+    },
+    {
+      "date": "2024-03-10",
+      "stock_id": "2330",
+      "country": "Taiwan",
+      "revenue": 195206000000,
+      "revenue_month": 3,
+      "revenue_year": 2024,
+      "revenue_month_growth": 7.48,
+      "revenue_year_growth": 34.31
+    },
+    {
+      "date": "2024-04-10",
+      "stock_id": "2330",
+      "country": "Taiwan",
+      "revenue": null,
+      "revenue_month": 4,
+      "revenue_year": 2024,
+      "revenue_month_growth": null,
+      "revenue_year_growth": null
+    }
+  ]
+}

--- a/ingestion/collectors/fixtures/google_news.xml
+++ b/ingestion/collectors/fixtures/google_news.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>2330 台積電 - Google 新聞</title>
+<link>https://news.google.com/search?q=2330</link>
+<description>Google News</description>
+<item>
+  <title>台積電 2330 Q3 毛利率再創新高</title>
+  <link>https://news.google.com/rss/articles/abc123</link>
+  <guid isPermaLink="false">abc123</guid>
+  <pubDate>Thu, 14 Nov 2024 08:30:00 GMT</pubDate>
+  <description>台積電公布 2024 年 Q3 財報，毛利率達 57.8%。關鍵字：[[CoWoS]] [[AI 伺服器]]</description>
+  <source url="https://www.example.com">聯合新聞網</source>
+</item>
+<item>
+  <title>聯發科與台積電合作 2nm 試產</title>
+  <link>https://news.google.com/rss/articles/def456</link>
+  <guid isPermaLink="false">def456</guid>
+  <pubDate>Wed, 13 Nov 2024 02:15:00 GMT</pubDate>
+  <description>[[聯發科]] 與 [[台積電]] 在 2nm 節點展開合作，預計 2026 年量產。</description>
+  <source url="https://www.example.com">經濟日報</source>
+</item>
+<item>
+  <title>Empty link should be skipped</title>
+  <link></link>
+  <pubDate>Wed, 13 Nov 2024 01:00:00 GMT</pubDate>
+  <description>no link here</description>
+</item>
+</channel></rss>

--- a/ingestion/collectors/fixtures/yahoo_article.html
+++ b/ingestion/collectors/fixtures/yahoo_article.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html><head><title>台積電亞利桑那廠再擴產</title></head>
+<body>
+<header>site header should not be captured</header>
+<article>
+  <h1>台積電亞利桑那廠再擴產</h1>
+  <p>[[台積電]] 今日宣布擴大在亞利桑那州的 [[CoWoS]] 產能投資。</p>
+  <p>公司 CEO 表示，為因應 [[NVIDIA]] 與 [[AMD]] 等 [[AI 伺服器]] 客戶需求，計畫加碼 40 億美元。</p>
+  <p>   </p>
+  <p>預計 2026 年第三季開始量產 3nm 製程。</p>
+</article>
+<footer>footer text</footer>
+</body></html>

--- a/ingestion/collectors/fixtures/yahoo_listing.html
+++ b/ingestion/collectors/fixtures/yahoo_listing.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html><head><title>2330 台積電 - Yahoo 股市</title></head>
+<body>
+<main>
+  <ul>
+    <li class="Card(b) js-card"><a href="/news/tsmc-arizona-expansion-112233.html">
+      台積電亞利桑那廠再擴產 投資金額上看 400 億美元
+      <time datetime="">3小時前</time>
+    </a></li>
+    <li class="StreamMegaItem Card"><a href="/news/tsmc-cowos-aiserver-445566.html" title="CoWoS 產能滿載 AI 伺服器需求拉動">
+      CoWoS 產能滿載 AI 伺服器需求拉動
+      <time datetime="">1天前</time>
+    </a></li>
+    <li class="Card Card2"><a href="/news/tsmc-3nm-yield-778899.html">
+      3nm 良率突破 9 成 台積電 2330 Q4 法說會預期正向
+      <time datetime="2024-11-15T02:00:00Z">2024-11-15</time>
+    </a></li>
+  </ul>
+</main>
+</body></html>

--- a/ingestion/collectors/google_news.py
+++ b/ingestion/collectors/google_news.py
@@ -1,0 +1,129 @@
+"""Google News RSS collector (per ticker).
+
+Queries `https://news.google.com/rss/search?q=<ticker>+<company_name>` with
+Traditional-Chinese locale and parses the RSS feed via feedparser. Writes to
+`news_items` with source='google'.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from urllib.parse import quote_plus
+
+import feedparser
+import httpx
+
+from ..ner import extract as ner_extract
+from ..universe import all_tickers, ticker_to_name
+from ._common import make_client, run_news_collector
+
+SOURCE = "google"
+FEED_URL = (
+    "https://news.google.com/rss/search?q={query}"
+    "&hl=zh-TW&gl=TW&ceid=TW:zh-Hant"
+)
+
+
+@dataclass
+class GoogleNewsItem:
+    title: str
+    source_url: str
+    published_at: datetime
+    body: str
+
+    def as_row(self) -> dict:
+        tickers, wikilinks = ner_extract(f"{self.title}\n{self.body}")
+        return {
+            "source_url": self.source_url,
+            "published_at": self.published_at,
+            "title": self.title,
+            "body": self.body,
+            "tickers": tickers,
+            "wikilinks": wikilinks,
+        }
+
+
+def build_feed_url(ticker: str, company_name: str | None) -> str:
+    terms = [ticker]
+    if company_name:
+        terms.append(company_name)
+    return FEED_URL.format(query=quote_plus(" ".join(terms)))
+
+
+def _entry_published(entry) -> datetime:
+    """feedparser gives us a UTC struct_time in `published_parsed` when it can
+    read the date; fall back to now() so the row still satisfies NOT NULL."""
+    tm = getattr(entry, "published_parsed", None) or getattr(entry, "updated_parsed", None)
+    if tm is None:
+        return datetime.now(timezone.utc)
+    return datetime(*tm[:6], tzinfo=timezone.utc)
+
+
+def parse_feed(xml_bytes: bytes, *, limit: int) -> list[GoogleNewsItem]:
+    parsed = feedparser.parse(xml_bytes)
+    items: list[GoogleNewsItem] = []
+    for entry in parsed.entries[:limit]:
+        link = (getattr(entry, "link", "") or "").strip()
+        title = (getattr(entry, "title", "") or "").strip()
+        if not link or not title:
+            continue
+        items.append(GoogleNewsItem(
+            title=title,
+            source_url=link,
+            published_at=_entry_published(entry),
+            body=(getattr(entry, "summary", "") or "").strip(),
+        ))
+    return items
+
+
+async def collect(
+    ticker: str,
+    *,
+    limit: int = 20,
+    client: httpx.AsyncClient | None = None,
+) -> list[GoogleNewsItem]:
+    url = build_feed_url(ticker, ticker_to_name(ticker))
+    own_client = client is None
+    client = client or make_client()
+    try:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return parse_feed(resp.content, limit=limit)
+    finally:
+        if own_client:
+            await client.aclose()
+
+
+def _preview(it: GoogleNewsItem) -> str:
+    return f"  {it.published_at.isoformat()} | {it.title}\n    {it.source_url}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Google News RSS collector")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--ticker", help="4-digit ticker, e.g. 2330")
+    group.add_argument("--all", action="store_true", help="iterate every electronics ticker")
+    parser.add_argument("--dry-run", action="store_true", help="parse + print; no DB write")
+    parser.add_argument("--limit", type=int, default=20, help="max items per ticker")
+    args = parser.parse_args(argv)
+
+    tickers = all_tickers() if args.all else [args.ticker]
+    if not tickers:
+        print("no tickers to process", file=sys.stderr)
+        return 1
+
+    async def _collect(ticker: str, client: httpx.AsyncClient) -> list[GoogleNewsItem]:
+        return await collect(ticker, limit=args.limit, client=client)
+
+    asyncio.run(run_news_collector(
+        SOURCE, tickers, _collect,
+        dry_run=args.dry_run, format_preview=_preview,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ingestion/collectors/test_search.py
+++ b/ingestion/collectors/test_search.py
@@ -1,0 +1,172 @@
+"""Unit tests for Unit 5 collectors (Yahoo/Google News/FinMind).
+
+Uses saved HTML/XML/JSON fixtures under ./fixtures/. Runs without network
+or Postgres. Execute with:
+
+    python3 -m unittest ingestion.collectors.test_search -v
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import finmind, google_news, yahoo_news
+from ._common import parse_relative_time
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_text(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _load_bytes(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+class RelativeTimeTests(unittest.TestCase):
+    def setUp(self):
+        self.now = datetime(2024, 11, 15, 12, 0, tzinfo=timezone.utc)
+
+    def test_chinese_hours(self):
+        result = parse_relative_time("3小時前", now=self.now)
+        self.assertEqual(result, datetime(2024, 11, 15, 9, 0, tzinfo=timezone.utc))
+
+    def test_chinese_days(self):
+        result = parse_relative_time("2天前", now=self.now)
+        self.assertEqual(result, datetime(2024, 11, 13, 12, 0, tzinfo=timezone.utc))
+
+    def test_english_hours(self):
+        result = parse_relative_time("5 hours ago", now=self.now)
+        self.assertEqual(result, datetime(2024, 11, 15, 7, 0, tzinfo=timezone.utc))
+
+    def test_iso_date_passthrough(self):
+        result = parse_relative_time("2024-11-15T02:00:00+00:00")
+        self.assertEqual(result, datetime(2024, 11, 15, 2, 0, tzinfo=timezone.utc))
+
+    def test_unparseable_returns_none(self):
+        self.assertIsNone(parse_relative_time("recently"))
+        self.assertIsNone(parse_relative_time(""))
+
+
+class YahooListingTests(unittest.TestCase):
+    def test_parses_three_items(self):
+        html = _load_text("yahoo_listing.html")
+        items = yahoo_news.parse_listing(html, "https://tw.stock.yahoo.com/")
+        self.assertEqual(len(items), 3)
+        # Titles are plain text (no surrounding whitespace or <time> leakage).
+        for it in items:
+            self.assertTrue(it["title"])
+            self.assertTrue(it["href"].startswith("https://"))
+        self.assertIn("台積電", items[0]["title"])
+
+    def test_time_text_captured(self):
+        html = _load_text("yahoo_listing.html")
+        items = yahoo_news.parse_listing(html, "https://tw.stock.yahoo.com/")
+        times = [it["time_text"] for it in items]
+        self.assertIn("3小時前", times)
+        self.assertTrue(any(t.startswith("2024-11-15") for t in times))
+
+    def test_deduplicates_repeated_hrefs(self):
+        html = (
+            '<a href="/news/dup-story-112233.html">Same article once</a>'
+            '<a href="/news/dup-story-112233.html">Same article twice</a>'
+        )
+        items = yahoo_news.parse_listing(html, "https://tw.stock.yahoo.com/")
+        self.assertEqual(len(items), 1)
+
+    def test_skips_navigation_tab(self):
+        # Yahoo renders its "news" tab as <a href="/news/">新聞</a>; that must
+        # never end up in the scraped items.
+        html = '<a href="/quote/2330.TW/news/">新聞</a><a href="/news/real-442211.html">真 新聞 標題</a>'
+        items = yahoo_news.parse_listing(html, "https://tw.stock.yahoo.com/")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["title"], "真 新聞 標題")
+
+
+class YahooArticleTests(unittest.TestCase):
+    def test_body_extracts_paragraphs(self):
+        html = _load_text("yahoo_article.html")
+        body = yahoo_news.parse_article(html)
+        self.assertIn("CoWoS", body)
+        self.assertIn("NVIDIA", body)
+        # Header and footer are outside <article>, so they must not leak in.
+        self.assertNotIn("site header", body)
+        self.assertNotIn("footer text", body)
+        # Empty <p></p> should not produce a blank line.
+        self.assertNotIn("\n\n", body)
+
+    def test_fallback_when_no_article_tag(self):
+        html = "<html><body><p>hello</p><p>world</p></body></html>"
+        self.assertEqual(yahoo_news.parse_article(html), "hello\nworld")
+
+
+class GoogleNewsFeedTests(unittest.TestCase):
+    def test_parses_two_valid_items(self):
+        items = google_news.parse_feed(_load_bytes("google_news.xml"), limit=10)
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0].title, "台積電 2330 Q3 毛利率再創新高")
+        self.assertEqual(items[0].source_url, "https://news.google.com/rss/articles/abc123")
+        self.assertEqual(
+            items[0].published_at,
+            datetime(2024, 11, 14, 8, 30, tzinfo=timezone.utc),
+        )
+
+    def test_limit_applied(self):
+        items = google_news.parse_feed(_load_bytes("google_news.xml"), limit=1)
+        self.assertEqual(len(items), 1)
+
+    def test_ner_populates_row(self):
+        items = google_news.parse_feed(_load_bytes("google_news.xml"), limit=10)
+        row = items[0].as_row()
+        self.assertIn("2330", row["tickers"])
+        self.assertIn("CoWoS", row["wikilinks"])
+
+    def test_build_feed_url_includes_company_name(self):
+        url = google_news.build_feed_url("2330", "台積電")
+        self.assertIn("2330", url)
+        # URL-encoded Chinese chars.
+        self.assertIn("hl=zh-TW", url)
+        self.assertIn("ceid=TW:zh-Hant", url)
+
+    def test_build_feed_url_without_company_name(self):
+        url = google_news.build_feed_url("9999", None)
+        self.assertIn("q=9999", url)
+
+
+class FinMindParserTests(unittest.TestCase):
+    def test_parses_revenue_rows(self):
+        payload = json.loads(_load_text("finmind_2330.json"))
+        rows = finmind.parse_rows("2330", payload)
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[0].report_month.isoformat(), "2024-01-01")
+        self.assertEqual(rows[0].monthly_revenue, 215793000000)
+        self.assertEqual(str(rows[0].yoy_pct), "7.88")
+
+    def test_nulls_become_none(self):
+        payload = json.loads(_load_text("finmind_2330.json"))
+        rows = finmind.parse_rows("2330", payload)
+        april = rows[3]
+        self.assertIsNone(april.monthly_revenue)
+        self.assertIsNone(april.yoy_pct)
+        self.assertIsNone(april.mom_pct)
+
+    def test_falls_back_to_date_field(self):
+        payload = {"data": [{"date": "2023-07-10", "revenue": 100, "stock_id": "2330"}]}
+        rows = finmind.parse_rows("2330", payload)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].report_month.isoformat(), "2023-07-01")
+
+    def test_empty_payload(self):
+        self.assertEqual(finmind.parse_rows("2330", {"data": []}), [])
+        self.assertEqual(finmind.parse_rows("2330", {}), [])
+
+    def test_since_to_start_date(self):
+        self.assertEqual(finmind._since_to_start_date("2024-01"), "2024-01-01")
+        self.assertEqual(finmind._since_to_start_date("2024-01-15"), "2024-01-15")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ingestion/collectors/yahoo_news.py
+++ b/ingestion/collectors/yahoo_news.py
@@ -1,0 +1,174 @@
+"""Yahoo Taiwan stock news collector.
+
+Scrapes `https://tw.stock.yahoo.com/quote/{ticker}.{suffix}/news` for a ticker
+(suffix is `TW` for TWSE-listed, `TWO` for OTC — we try TW first, fall back
+on 404). Parses listing + article pages with BeautifulSoup using robust
+attribute-substring selectors because Yahoo rotates generated class names.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from ..ner import extract as ner_extract
+from ..universe import all_tickers
+from ._common import make_client, parse_relative_time, run_news_collector
+
+SOURCE = "yahoo"
+LISTING_URL = "https://tw.stock.yahoo.com/quote/{ticker}.{suffix}/news"
+RATE_LIMIT_SECONDS = 1.0
+
+
+@dataclass
+class YahooNewsItem:
+    title: str
+    source_url: str
+    published_at: datetime
+    body: str
+
+    def as_row(self) -> dict:
+        tickers, wikilinks = ner_extract(f"{self.title}\n{self.body}")
+        return {
+            "source_url": self.source_url,
+            "published_at": self.published_at,
+            "title": self.title,
+            "body": self.body,
+            "tickers": tickers,
+            "wikilinks": wikilinks,
+        }
+
+
+def parse_listing(html: str, base_url: str) -> list[dict]:
+    """Extract (title, href, time_text) triples from a Yahoo listing page."""
+    soup = BeautifulSoup(html, "lxml")
+    items: list[dict] = []
+    seen: set[str] = set()
+
+    # Prefer the robust selector, but fall back to any anchor pointing at /news/.
+    anchors = soup.select('li[class*="Card"] a[href*="/news/"]')
+    if not anchors:
+        anchors = soup.select('a[href*="/news/"]')
+
+    for a in anchors:
+        href = (a.get("href") or "").strip()
+        if not href or href in seen:
+            continue
+        # Skip the navigation tab ("/news" or "/news/") and other non-article hrefs.
+        # Real Yahoo article hrefs are shaped "/news/<slug>-<digits>.html".
+        if not href.rstrip("/").split("/")[-1].endswith(".html"):
+            continue
+        title = (a.get_text(strip=True) or a.get("title") or "").strip()
+        if not title or len(title) < 6:
+            continue
+        # Nearby <time> element (if present) gives us the relative or ISO stamp.
+        time_text = ""
+        time_el = a.find("time") or a.find_next("time")
+        if time_el:
+            time_text = (time_el.get("datetime") or time_el.get_text(strip=True) or "").strip()
+        items.append({
+            "title": title,
+            "href": urljoin(base_url, href),
+            "time_text": time_text,
+        })
+        seen.add(href)
+    return items
+
+
+def parse_article(html: str) -> str:
+    """Extract the main text of a Yahoo article page as a single string."""
+    soup = BeautifulSoup(html, "lxml")
+    # Yahoo articles consistently wrap body copy in <article>; fall back to
+    # concatenated <p> tags when the wrapper markup changes.
+    article = soup.find("article")
+    root = article if article else soup
+    paragraphs = [p.get_text(" ", strip=True) for p in root.find_all("p")]
+    return "\n".join(p for p in paragraphs if p)
+
+
+async def _fetch_listing_html(client: httpx.AsyncClient, ticker: str) -> str | None:
+    """Try .TW, fall back to .TWO on 404. Returns HTML or None if both fail."""
+    for suffix in ("TW", "TWO"):
+        url = LISTING_URL.format(ticker=ticker, suffix=suffix)
+        resp = await client.get(url)
+        if resp.status_code == 404:
+            continue
+        resp.raise_for_status()
+        return resp.text
+    return None
+
+
+async def collect(
+    ticker: str,
+    *,
+    limit: int = 20,
+    client: httpx.AsyncClient | None = None,
+) -> list[YahooNewsItem]:
+    own_client = client is None
+    client = client or make_client()
+    try:
+        listing_html = await _fetch_listing_html(client, ticker)
+        if listing_html is None:
+            return []
+        base_url = LISTING_URL.format(ticker=ticker, suffix="TW")
+        parsed = parse_listing(listing_html, base_url)[:limit]
+
+        items: list[YahooNewsItem] = []
+        for entry in parsed:
+            await asyncio.sleep(RATE_LIMIT_SECONDS)
+            try:
+                article_resp = await client.get(entry["href"])
+                article_resp.raise_for_status()
+                body = parse_article(article_resp.text)
+            except httpx.HTTPError as exc:
+                print(f"  skip {entry['href']}: {exc}", file=sys.stderr)
+                continue
+            published = parse_relative_time(entry["time_text"]) or datetime.now(timezone.utc)
+            items.append(YahooNewsItem(
+                title=entry["title"],
+                source_url=entry["href"],
+                published_at=published,
+                body=body,
+            ))
+        return items
+    finally:
+        if own_client:
+            await client.aclose()
+
+
+def _preview(it: YahooNewsItem) -> str:
+    return f"  {it.published_at.isoformat()} | {it.title}\n    {it.source_url}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Yahoo 股市 news collector")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--ticker", help="4-digit ticker, e.g. 2330")
+    group.add_argument("--all", action="store_true", help="iterate every electronics ticker")
+    parser.add_argument("--dry-run", action="store_true", help="parse + print; no DB write")
+    parser.add_argument("--limit", type=int, default=20, help="max items per ticker")
+    args = parser.parse_args(argv)
+
+    tickers = all_tickers() if args.all else [args.ticker]
+    if not tickers:
+        print("no tickers to process", file=sys.stderr)
+        return 1
+
+    async def _collect(ticker: str, client: httpx.AsyncClient) -> list[YahooNewsItem]:
+        return await collect(ticker, limit=args.limit, client=client)
+
+    asyncio.run(run_news_collector(
+        SOURCE, tickers, _collect,
+        dry_run=args.dry_run, format_preview=_preview,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ pydantic-settings>=2.0
 
 # Unit 4 — RSS collectors
 feedparser>=6.0
+
+# Unit 5 — Search + fundamentals collectors
+beautifulsoup4>=4.12
+lxml>=5.0


### PR DESCRIPTION
## Summary
- Adds `ingestion/collectors/{yahoo_news,google_news,finmind}.py` plus a tiny shared driver (`_common.py`) that Yahoo and Google News share (relative-time parser, `news_items` upsert, per-ticker loop).
- Yahoo scraper: `tw.stock.yahoo.com/quote/{ticker}.TW/news` with `.TWO` fallback, BeautifulSoup with attribute-substring selectors, 1 req/sec rate limit, filters the navigation tab and other non-article hrefs.
- Google News: RSS per ticker, resolves company name via `ingestion.universe.ticker_to_name()` for stronger recall (`q=2330+台積電`).
- FinMind: `TaiwanStockMonthRevenue` via free tier (optional `FINMIND_TOKEN`), upserts `finmind_fundamentals`, sleeps 5s and retries once on HTTP 402/429. Free tier omits growth fields, so YoY/MoM are derived locally from consecutive revenue values.
- Stubs for Unit 2 modules (`ingestion/{config,db,universe,ner}.py`) so this unit can run and be tested ahead of Unit 2's merge. They expose the same surface area and will be replaced when Unit 2 lands.
- 21 unit tests under `ingestion/collectors/test_search.py` exercising listing + article parsing, Google RSS, FinMind row normalization (including null growth fields and the `date` fallback), and the shared relative-time parser. Fixtures live in `ingestion/collectors/fixtures/`.

## Test plan
- [x] `python3 -m unittest ingestion.collectors.test_search -v` — 21/21 passing
- [x] `python3 -m ingestion.collectors.yahoo_news --ticker 2330 --dry-run --limit 3` — returns real article URLs; nav tab filtered out
- [x] `python3 -m ingestion.collectors.google_news --ticker 2330 --dry-run --limit 3` — returns live RSS entries
- [x] `python3 -m ingestion.collectors.finmind --ticker 2330 --since 2024-01 --dry-run` — returns monthly revenue rows with derived MoM/YoY
- [ ] Live DB write against `knowledge-platform-postgres-1` — not run locally (container not present on this machine). Upsert path reviewed via fixture tests + SQL inspection.

Notes:
- FinMind free tier returns only `{date, stock_id, country, revenue, revenue_month, revenue_year, create_time}` — no growth fields. We derive YoY/MoM from adjacent-month revenues so downstream consumers still get numeric values.
- Yahoo's listing often surfaces a `<a href="/quote/2330.TW/news/">新聞</a>` navigation tab alongside real articles; the parser now requires a `.html` suffix on the final path segment to skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)