### PR TITLE
Unit 6: Graph layer (Graphiti + bootstrap)

### DIFF
--- a/graph/bootstrap.py
+++ b/graph/bootstrap.py
@@ -1,0 +1,237 @@
+"""Bootstrap ingester: convert Pilot_Reports Markdown into Graphiti episodes.
+
+Scans ``Pilot_Reports/<Sector>/<Ticker>_<Name>.md``, parses the
+``## 供應鏈位置`` and ``## 主要客戶及供應商`` sections into a plain-text
+episode body, and calls ``graphiti.add_episode(...)``.
+
+The parser is section-and-bullet aware: it extracts every bullet line and
+flattens "上游", "中游", "下游", "主要客戶", "主要供應商" into lists with
+minimal assumptions. Whatever cannot be confidently classified falls into a
+generic "other" bucket so no information is silently dropped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORTS_DIR = REPO_ROOT / "Pilot_Reports"
+
+FILENAME_RE = re.compile(r"^(\d{4})_(.+)\.md$")
+_LABEL_RE = re.compile(r"^\*\*([^*]+)\*\*\s*:?\s*$")
+_INLINE_LABEL_RE = re.compile(r"^-\s*\*\*([^*]+)\*\*\s*:?\s*(.*)$")
+_BULLET_RE = re.compile(r"^[-*]\s+(.*)$")
+
+UPSTREAM_KEYS = ("上游",)
+MIDSTREAM_KEYS = ("中游",)
+DOWNSTREAM_KEYS = ("下游",)  # "下游應用" also matches via substring
+CUSTOMER_KEYS = ("主要客戶", "客戶")
+SUPPLIER_KEYS = ("主要供應商", "供應商")
+
+
+@dataclass
+class ParsedReport:
+    ticker: str
+    company_name: str
+    sector: str
+    upstream: list[str] = field(default_factory=list)
+    midstream: list[str] = field(default_factory=list)
+    downstream: list[str] = field(default_factory=list)
+    customers: list[str] = field(default_factory=list)
+    suppliers: list[str] = field(default_factory=list)
+    other_supply_chain: list[str] = field(default_factory=list)
+
+    def to_episode_body(self) -> str:
+        def fmt(items: list[str]) -> str:
+            return "; ".join(items) if items else "(not specified)"
+
+        lines = [
+            f"{self.ticker} ({self.company_name}) supply chain and customer/supplier relationships:",
+            f"Upstream: {fmt(self.upstream)}",
+            f"Midstream: {fmt(self.midstream)}",
+            f"Downstream: {fmt(self.downstream)}",
+            f"Major customers: {fmt(self.customers)}",
+            f"Major suppliers: {fmt(self.suppliers)}",
+        ]
+        if self.other_supply_chain:
+            lines.append(f"Other supply-chain notes: {fmt(self.other_supply_chain)}")
+        return "\n".join(lines)
+
+
+def _iter_report_paths(sector: str | None = None) -> Iterable[Path]:
+    if not REPORTS_DIR.is_dir():
+        return []
+    if sector is not None:
+        sector_dir = REPORTS_DIR / sector
+        if not sector_dir.is_dir():
+            return []
+        return sorted(sector_dir.glob("*.md"))
+    return sorted(REPORTS_DIR.glob("*/*.md"))
+
+
+def _split_sections(markdown: str) -> dict[str, str]:
+    """Split a Markdown document by H2 headings into name -> body text."""
+    sections: dict[str, str] = {}
+    current_name: str | None = None
+    current_lines: list[str] = []
+    for line in markdown.splitlines():
+        if line.startswith("## "):
+            if current_name is not None:
+                sections[current_name] = "\n".join(current_lines).strip()
+            current_name = line[3:].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_name is not None:
+        sections[current_name] = "\n".join(current_lines).strip()
+    return sections
+
+
+def _bullets(section_body: str) -> list[tuple[str | None, str]]:
+    """Yield (sub_label, bullet_text) for each bullet.
+
+    A bullet's sub_label is the nearest preceding bold prefix like
+    ``**上游 (原料):**`` so callers can route bullets to the right bucket.
+    """
+    results: list[tuple[str | None, str]] = []
+    current_label: str | None = None
+
+    for raw in section_body.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        m = _LABEL_RE.match(line)
+        if m:
+            current_label = m.group(1).strip()
+            continue
+        if line.startswith("### "):
+            current_label = line[4:].strip()
+            continue
+        m = _INLINE_LABEL_RE.match(line)
+        if m:
+            sub_label = m.group(1).strip()
+            rest = m.group(2).strip()
+            effective_label = sub_label if not current_label else f"{current_label} / {sub_label}"
+            if rest:
+                results.append((effective_label, rest))
+            else:
+                current_label = sub_label
+            continue
+        m = _BULLET_RE.match(line)
+        if m:
+            results.append((current_label, m.group(1).strip()))
+    return results
+
+
+def _classify(label: str | None, keys: tuple[str, ...]) -> bool:
+    if not label:
+        return False
+    return any(k in label for k in keys)
+
+
+def parse_report(path: Path) -> ParsedReport:
+    """Read one report file and return a ParsedReport."""
+    filename = path.name
+    m = FILENAME_RE.match(filename)
+    if not m:
+        raise ValueError(f"Filename does not match XXXX_name.md pattern: {filename}")
+    ticker, name = m.group(1), m.group(2)
+    sector = path.parent.name
+
+    text = path.read_text(encoding="utf-8")
+    sections = _split_sections(text)
+
+    report = ParsedReport(ticker=ticker, company_name=name, sector=sector)
+
+    supply_section = sections.get("供應鏈位置", "")
+    for label, bullet in _bullets(supply_section):
+        if _classify(label, UPSTREAM_KEYS):
+            report.upstream.append(bullet)
+        elif _classify(label, MIDSTREAM_KEYS):
+            report.midstream.append(bullet)
+        elif _classify(label, DOWNSTREAM_KEYS):
+            report.downstream.append(bullet)
+        else:
+            report.other_supply_chain.append(bullet if not label else f"{label}: {bullet}")
+
+    customer_section = sections.get("主要客戶及供應商", "")
+    for label, bullet in _bullets(customer_section):
+        if _classify(label, CUSTOMER_KEYS):
+            report.customers.append(bullet)
+        elif _classify(label, SUPPLIER_KEYS):
+            report.suppliers.append(bullet)
+        else:
+            # Fall back: bullets with no label under this section are ambiguous;
+            # preserve them in customers to avoid silent loss.
+            report.customers.append(bullet if not label else f"{label}: {bullet}")
+
+    return report
+
+
+async def ingest(reports: list[ParsedReport], dry_run: bool) -> None:
+    if dry_run:
+        for r in reports:
+            print(json.dumps({
+                "name": r.ticker,
+                "sector": r.sector,
+                "episode_body": r.to_episode_body(),
+            }, ensure_ascii=False))
+        return
+
+    from graph.client import GROUP_ID, get_client  # local import so --dry-run works without deps
+    from graphiti_core.nodes import EpisodeType
+
+    client = await get_client()
+    for r in reports:
+        try:
+            await client.add_episode(
+                name=r.ticker,
+                episode_body=r.to_episode_body(),
+                source=EpisodeType.text,
+                source_description="pilot_reports: Taiwan electronics supply chain research",
+                reference_time=datetime.now(),
+                group_id=GROUP_ID,
+            )
+            print(f"[ok] {r.ticker} {r.company_name}")
+        except Exception as e:  # noqa: BLE001 — one failure shouldn't stop the batch
+            print(f"[err] {r.ticker} {r.company_name}: {e}")
+
+
+def collect_reports(sector: str | None, limit: int | None) -> list[ParsedReport]:
+    paths = list(_iter_report_paths(sector))
+    if limit is not None:
+        paths = paths[:limit]
+    parsed: list[ParsedReport] = []
+    for p in paths:
+        try:
+            parsed.append(parse_report(p))
+        except Exception as e:  # noqa: BLE001
+            print(f"[skip] {p}: {e}")
+    return parsed
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest Pilot_Reports into Graphiti")
+    parser.add_argument("--limit", type=int, default=None, help="Process only the first N reports")
+    parser.add_argument("--dry-run", action="store_true", help="Print episode payloads without calling Graphiti")
+    parser.add_argument("--sector", type=str, default=None, help="Process one sector only (folder name under Pilot_Reports)")
+    args = parser.parse_args()
+
+    reports = collect_reports(args.sector, args.limit)
+    if not reports:
+        print("No reports matched.")
+        return
+
+    asyncio.run(ingest(reports, args.dry_run))
+
+
+if __name__ == "__main__":
+    _main()

--- a/graph/client.py
+++ b/graph/client.py
@@ -1,0 +1,118 @@
+"""Graphiti client wrapper for the Taiwan-electronics supply-chain graph.
+
+Configures Graphiti against a local FalkorDB + Ollama stack, partitioned by
+``group_id="tw-electronics"``. Mirrors the reference implementation at
+``Knowledge_manager/mcp_servers/graphiti_server.py`` so both personal and
+project namespaces share the same infrastructure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from typing import Any
+
+FALKORDB_HOST = os.getenv("FALKORDB_HOST", "localhost")
+FALKORDB_PORT = int(os.getenv("FALKORDB_PORT", "6380"))
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "bge-m3")
+EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1024"))
+LLM_MODEL = os.getenv("GRAPHITI_LLM_MODEL", "qwen2.5:7b")
+GROUP_ID = os.getenv("GRAPHITI_GROUP_ID", "tw-electronics")
+
+_client: Any | None = None
+_client_lock = asyncio.Lock()
+
+
+async def get_client() -> Any:
+    """Lazy singleton for the Graphiti client."""
+    global _client
+    if _client is not None:
+        return _client
+
+    async with _client_lock:
+        if _client is not None:
+            return _client
+
+        from graphiti_core import Graphiti
+        from graphiti_core.driver.falkordb_driver import FalkorDriver
+        from graphiti_core.embedder import OpenAIEmbedder, OpenAIEmbedderConfig
+        from graphiti_core.cross_encoder import OpenAIRerankerClient
+        from graphiti_core.llm_client import LLMConfig, OpenAIClient
+
+        llm_config = LLMConfig(
+            api_key="ollama",
+            base_url=f"{OLLAMA_BASE_URL}/v1",
+            model=LLM_MODEL,
+            small_model=LLM_MODEL,
+        )
+
+        driver = FalkorDriver(host=FALKORDB_HOST, port=FALKORDB_PORT)
+
+        client = Graphiti(
+            graph_driver=driver,
+            llm_client=OpenAIClient(llm_config),
+            embedder=OpenAIEmbedder(OpenAIEmbedderConfig(
+                api_key="ollama",
+                base_url=f"{OLLAMA_BASE_URL}/v1",
+                embedding_model=EMBEDDING_MODEL,
+                embedding_dim=EMBEDDING_DIM,
+            )),
+            cross_encoder=OpenAIRerankerClient(config=llm_config),
+        )
+
+        await client.build_indices_and_constraints()
+        _client = client
+        return _client
+
+
+async def health_check() -> dict:
+    """Probe FalkorDB and Ollama; return a simple status dict."""
+    falkor_status = "error"
+    try:
+        import redis.asyncio as aioredis
+
+        r = aioredis.Redis(host=FALKORDB_HOST, port=FALKORDB_PORT)
+        try:
+            await r.ping()
+            falkor_status = "connected"
+        finally:
+            await r.aclose()
+    except Exception:
+        falkor_status = "error"
+
+    ollama_status = "error"
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=5) as http:
+            resp = await http.get(f"{OLLAMA_BASE_URL}/api/tags")
+            if resp.status_code == 200:
+                ollama_status = "connected"
+    except Exception:
+        ollama_status = "error"
+
+    return {
+        "falkor": falkor_status,
+        "ollama": ollama_status,
+        "group_id": GROUP_ID,
+    }
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Graphiti client utilities")
+    parser.add_argument("--health", action="store_true", help="Print health status as JSON")
+    args = parser.parse_args()
+
+    if args.health:
+        result = asyncio.run(health_check())
+        print(json.dumps(result))
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    _main()

--- a/graph/incremental.py
+++ b/graph/incremental.py
@@ -1,0 +1,103 @@
+"""News-driven incremental writer for the supply-chain graph.
+
+Intended to be called by an ingestion/scheduler layer (Unit 7) once per
+news item. The gate: ingest only when the item is obviously supply-chain
+relevant — either multiple tickers appear together, or a canonical
+supply-chain verb is present.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+SUPPLY_CHAIN_VERB_RE = re.compile(r"供貨|採購|代工|出貨|委外|獨家|中標|得標|合作")
+_TICKER_SPLIT_RE = re.compile(r"[,\s]+")
+_TEXT_KEYS = ("title", "summary", "content", "body")
+
+
+def _extract_tickers(news_item: dict) -> list[str]:
+    tickers = news_item.get("tickers") or []
+    if isinstance(tickers, str):
+        return [t for t in _TICKER_SPLIT_RE.split(tickers) if t]
+    return list(tickers)
+
+
+def _is_supply_chain_relevant(news_item: dict) -> bool:
+    if len(_extract_tickers(news_item)) >= 2:
+        return True
+    text_blob = " ".join(
+        v for k in _TEXT_KEYS if isinstance((v := news_item.get(k)), str) and v
+    )
+    return bool(SUPPLY_CHAIN_VERB_RE.search(text_blob))
+
+
+def _episode_body(news_item: dict) -> str:
+    title = news_item.get("title") or ""
+    summary = news_item.get("summary") or news_item.get("content") or news_item.get("body") or ""
+    tickers = _extract_tickers(news_item)
+    published = news_item.get("published_at") or news_item.get("date") or ""
+    source = news_item.get("source") or ""
+
+    lines = [f"News: {title}"]
+    if tickers:
+        lines.append(f"Tickers: {', '.join(tickers)}")
+    if source:
+        lines.append(f"Source: {source}")
+    if published:
+        lines.append(f"Published: {published}")
+    if summary:
+        lines.append("")
+        lines.append(summary)
+    return "\n".join(lines)
+
+
+def _reference_time(news_item: dict) -> datetime:
+    raw = news_item.get("published_at") or news_item.get("date")
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+        for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(raw, fmt)
+            except ValueError:
+                continue
+    return datetime.now()
+
+
+async def ingest_news_as_episode(news_item: dict) -> dict[str, Any]:
+    """Ingest a single news_items row as a Graphiti episode if relevant.
+
+    Returns a small status dict describing what happened. Does not raise on
+    relevance-gate failures — those return ``{"status": "skipped", ...}``.
+    """
+    if not _is_supply_chain_relevant(news_item):
+        return {"status": "skipped", "reason": "not supply-chain relevant"}
+
+    from graph.client import GROUP_ID, get_client  # local import keeps module importable without deps
+    from graphiti_core.nodes import EpisodeType
+
+    client = await get_client()
+    news_id = news_item.get("id") or news_item.get("uuid") or "unknown"
+    name = f"news:{news_id}"
+    try:
+        episode = await client.add_episode(
+            name=name,
+            episode_body=_episode_body(news_item),
+            source=EpisodeType.text,
+            source_description="news: Taiwan electronics supply-chain news",
+            reference_time=_reference_time(news_item),
+            group_id=GROUP_ID,
+        )
+        return {
+            "status": "ingested",
+            "name": name,
+            "episode_uuid": getattr(episode, "uuid", str(episode)),
+        }
+    except Exception as e:  # noqa: BLE001
+        return {"status": "error", "name": name, "error": str(e)}

--- a/graph/test_bootstrap.py
+++ b/graph/test_bootstrap.py
@@ -1,0 +1,95 @@
+"""Tests for the Markdown section-and-bullet parser in graph.bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from graph.bootstrap import (
+    _bullets,
+    _split_sections,
+    collect_reports,
+    parse_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TSMC_REPORT = REPO_ROOT / "Pilot_Reports" / "Semiconductors" / "2330_台積電.md"
+
+
+def test_split_sections_extracts_h2_headings() -> None:
+    md = "# Title\n\n## A\nalpha\n\n## B\nbeta\nbeta2\n\n## C\n"
+    sections = _split_sections(md)
+    assert "A" in sections and "B" in sections and "C" in sections
+    assert sections["A"] == "alpha"
+    assert sections["B"] == "beta\nbeta2"
+    assert sections["C"] == ""
+
+
+def test_bullets_captures_bold_prefix_label() -> None:
+    body = (
+        "**上游 (設備/原料):**\n"
+        "- **設備:** [[ASML]], [[Applied Materials]].\n"
+        "- **材料:** [[環球晶]], [[Shin-Etsu]].\n"
+        "\n"
+        "**下游應用:**\n"
+        "- **主要平台:** HPC, Smartphone.\n"
+    )
+    bullets = _bullets(body)
+    # Each bullet should carry a label containing the parent section bold prefix.
+    labels = [b[0] for b in bullets]
+    texts = [b[1] for b in bullets]
+    assert any("上游" in (lbl or "") for lbl in labels)
+    assert any("下游" in (lbl or "") for lbl in labels)
+    assert any("ASML" in t for t in texts)
+    assert any("HPC" in t for t in texts)
+
+
+def test_bullets_handles_h3_labels() -> None:
+    body = (
+        "### 主要客戶\n"
+        "- [[Apple]] (>20%)\n"
+        "- [[NVIDIA]]\n"
+        "\n"
+        "### 主要供應商\n"
+        "- [[ASML]]\n"
+    )
+    bullets = _bullets(body)
+    labels = {b[0] for b in bullets}
+    assert "主要客戶" in labels
+    assert "主要供應商" in labels
+
+
+@pytest.mark.skipif(not TSMC_REPORT.exists(), reason="TSMC fixture missing")
+def test_parse_tsmc_report_populates_all_buckets() -> None:
+    parsed = parse_report(TSMC_REPORT)
+    assert parsed.ticker == "2330"
+    assert parsed.company_name == "台積電"
+    assert parsed.sector == "Semiconductors"
+
+    assert parsed.upstream, "upstream bullets expected"
+    assert any("ASML" in b for b in parsed.upstream)
+    assert parsed.downstream, "downstream bullets expected"
+    assert any("NVIDIA" in b or "AMD" in b or "iPhone" in b for b in parsed.downstream)
+
+    assert parsed.customers, "customers expected"
+    assert any("Apple" in b for b in parsed.customers)
+    assert parsed.suppliers, "suppliers expected"
+    assert any("ASML" in b for b in parsed.suppliers)
+
+
+@pytest.mark.skipif(not TSMC_REPORT.exists(), reason="TSMC fixture missing")
+def test_episode_body_contains_all_labels() -> None:
+    parsed = parse_report(TSMC_REPORT)
+    body = parsed.to_episode_body()
+    assert body.startswith("2330 (台積電) supply chain")
+    for marker in ("Upstream:", "Midstream:", "Downstream:", "Major customers:", "Major suppliers:"):
+        assert marker in body
+
+
+def test_collect_reports_honors_limit() -> None:
+    reports = collect_reports(sector="Semiconductors", limit=2)
+    assert len(reports) <= 2
+    for r in reports:
+        assert r.ticker.isdigit()
+        assert r.sector == "Semiconductors"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,7 @@ feedparser>=6.0
 # Unit 5 — Search + fundamentals collectors
 beautifulsoup4>=4.12
 lxml>=5.0
+
+# Unit 6 — Graph layer (Graphiti + FalkorDB)
+graphiti-core>=0.3
+falkordb>=1.0


### PR DESCRIPTION
## Summary
- New `graph/` package: Graphiti client wrapper, one-shot bootstrap ingester, news-driven incremental writer.
- Config from env: `FALKORDB_HOST`/`FALKORDB_PORT`/`OLLAMA_BASE_URL`/`EMBEDDING_MODEL`/`GRAPHITI_GROUP_ID`. Defaults match the companion stack (FalkorDB on 6380, Ollama on 11434, bge-m3, group `tw-electronics`).
- Parses `## 供應鏈位置` and `## 主要客戶及供應商` from each Pilot_Reports md, buckets bullets into upstream/midstream/downstream/customers/suppliers, and emits one episode per ticker.
- `requirements.txt` appended with `graphiti-core>=0.3` and `falkordb>=1.0` under `# Unit 6`.

## Verification

```
$ python3 -m pytest graph/test_bootstrap.py -v
==================== 6 passed in 0.01s ====================

$ python3 -m graph.client --health
{"falkor": "connected", "ollama": "connected", "group_id": "tw-electronics"}

$ python3 -m graph.bootstrap --limit 3 --dry-run
<prints 3 JSON payloads with ticker / sector / episode_body>

$ GRAPHITI_GROUP_ID=tw_electronics python3 -m graph.bootstrap --limit 5
[ok] 6136 富爾特
[ok] 2208 台船
[ok] 2630 亞航
[ok] 2634 漢翔
[ok] 2644 中信造船

$ docker exec knowledge-platform-falkordb-1 redis-cli -p 6379 \
    GRAPH.QUERY tw_electronics 'MATCH (n:Entity) RETURN count(n)'
count(n) = 100
```

## Gotcha (documented per spec)

The mission's default `group_id="tw-electronics"` works at **write** time but breaks at **search** time under the current Graphiti + FalkorDB combo — FalkorDB's RediSearch tokenizer treats `-` as a separator, so `@group_id:"tw-electronics"` fails with `Syntax error at offset 14 near tw`. For live ingestion/queries today, export `GRAPHITI_GROUP_ID=tw_electronics`. The default in `graph/client.py` is kept as `tw-electronics` to match the spec once Graphiti upstream properly quotes the token.

Also note: graphiti-core 0.28's `add_episode(source=...)` expects `EpisodeType` (enum), not a free-form string. We pass `EpisodeType.text` and push the `"pilot_reports"` / `"news"` source tag into `source_description`.

## Test plan
- [x] Unit tests: `python3 -m pytest graph/test_bootstrap.py -v` — 6/6 pass
- [x] Health check: `python3 -m graph.client --health` — both connected
- [x] Dry-run: `python3 -m graph.bootstrap --limit 3 --dry-run` — 3 payloads emitted
- [x] Live bootstrap: 5 episodes → 100 entities in FalkorDB (with `GRAPHITI_GROUP_ID=tw_electronics`)
- [ ] Full 926-report ingestion (out of scope for this PR — will be run by the scheduler/Unit 7)

Generated with Claude Code.